### PR TITLE
Add python-devel as required for Kerberos

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ sudo apt-get install python-dev libkrb5-dev
 $ pip install pywinrm[kerberos]
 
 # for RHEL/CentOS/etc:
-$ sudo yum install gcc krb5-devel krb5-workstation
+$ sudo yum install gcc krb5-devel krb5-workstation python-devel
 $ pip install pywinrm[kerberos]
 ```
 


### PR DESCRIPTION
On RHEL systems, python dev[el] are needed to compile requests-kerberos.
